### PR TITLE
Specify data-file encoding

### DIFF
--- a/src/precomputed-tables.lisp
+++ b/src/precomputed-tables.lisp
@@ -9,7 +9,7 @@
 
 
 (defvar *unicode-data*
-  (with-open-file (in (uiop:merge-pathnames* *data-directory* "UnicodeData.txt") :external-format :ISO-8859-1)
+  (with-open-file (in (uiop:merge-pathnames* *data-directory* "UnicodeData.txt") :external-format :UTF-8)
     (loop for line = (read-line in nil nil)
        while line
        collect (cl-ppcre:split ";" line))))
@@ -41,7 +41,7 @@
 
 
 (defparameter *composition-exclusions-data* (make-hash-table))
-(with-open-file (in (uiop:merge-pathnames* *data-directory* "CompositionExclusions.txt" :external-format :ISO-8859-1))
+(with-open-file (in (uiop:merge-pathnames* *data-directory* "CompositionExclusions.txt" :external-format :UTF-8))
   (loop for line = (read-line in nil nil)
      while line
        when (and (plusp (length line))

--- a/src/precomputed-tables.lisp
+++ b/src/precomputed-tables.lisp
@@ -9,7 +9,7 @@
 
 
 (defvar *unicode-data*
-  (with-open-file (in (uiop:merge-pathnames* *data-directory* "UnicodeData.txt"))
+  (with-open-file (in (uiop:merge-pathnames* *data-directory* "UnicodeData.txt") :external-format :ISO-8859-1)
     (loop for line = (read-line in nil nil)
        while line
        collect (cl-ppcre:split ";" line))))
@@ -41,7 +41,7 @@
 
 
 (defparameter *composition-exclusions-data* (make-hash-table))
-(with-open-file (in (uiop:merge-pathnames* *data-directory* "CompositionExclusions.txt"))
+(with-open-file (in (uiop:merge-pathnames* *data-directory* "CompositionExclusions.txt" :external-format :ISO-8859-1))
   (loop for line = (read-line in nil nil)
      while line
        when (and (plusp (length line))

--- a/src/uax-15.lisp
+++ b/src/uax-15.lisp
@@ -67,7 +67,7 @@
              (loop for code from (first range) to (or (second range) (first range))
                    for char = code
                collect (list char maybe?)))))
-    (with-open-file (in *derived-normalization-props-data-file* :external-format :ISO-8859-1)
+    (with-open-file (in *derived-normalization-props-data-file* :external-format :UTF-8)
       (loop for line = (read-line in nil nil)
             while line
         do

--- a/src/uax-15.lisp
+++ b/src/uax-15.lisp
@@ -67,7 +67,7 @@
              (loop for code from (first range) to (or (second range) (first range))
                    for char = code
                collect (list char maybe?)))))
-    (with-open-file (in *derived-normalization-props-data-file*)
+    (with-open-file (in *derived-normalization-props-data-file* :external-format :ISO-8859-1)
       (loop for line = (read-line in nil nil)
             while line
         do


### PR DESCRIPTION
Fixes #4 

SBCL 1.4.5 on Debian assumes a default encoding of `:ANSI_X3.4-1968` (this is read from `sb-impl::*default-external-format*`)
Since the data files are encoded in `:ISO-8859-1`, this causes the linked bug (a stream decoding error)

Presumably the interpreter's default file encoding depends on the implementation & system locale.
By specifying the encoding in the `with-open-file` blocks, we resolve this issue no matter what the defaults are.