### PR TITLE
Add support for LispWorks

### DIFF
--- a/src/precomputed-tables.lisp
+++ b/src/precomputed-tables.lisp
@@ -10,7 +10,7 @@
 
 (defvar *unicode-data*
   (with-open-file (in (uiop:merge-pathnames* *data-directory* "UnicodeData.txt")
-                      :external-format :UTF-8)
+                      #-:lispworks :external-format #-:lispworks :UTF-8)
     (loop for line = (read-line in nil nil)
        while line
        collect (cl-ppcre:split ";" line))))
@@ -43,7 +43,7 @@
 
 (defparameter *composition-exclusions-data* (make-hash-table))
 (with-open-file (in (uiop:merge-pathnames* *data-directory* "CompositionExclusions.txt")
-                    :external-format :UTF-8)
+                    #-:lispworks :external-format #-:lispworks :UTF-8)
   (loop for line = (read-line in nil nil)
      while line
        when (and (plusp (length line))

--- a/src/uax-15.lisp
+++ b/src/uax-15.lisp
@@ -67,7 +67,8 @@
              (loop for code from (first range) to (or (second range) (first range))
                    for char = code
                collect (list char maybe?)))))
-    (with-open-file (in *derived-normalization-props-data-file* :external-format :UTF-8)
+    (with-open-file (in *derived-normalization-props-data-file*
+                        #-:lispworks :external-format #-:lispworks :UTF-8)
       (loop for line = (read-line in nil nil)
             while line
         do


### PR DESCRIPTION
LispWorks chokes in `with-open-file` having `:external-format :UTF-8` arguments.  Works fine without it.